### PR TITLE
Restore Webhooks export in resources/index.ts

### DIFF
--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -298,4 +298,5 @@ export {
   type VirtualAccountListParams,
   type VirtualAccountsPage,
 } from './virtual-accounts';
+export { Webhooks } from './webhooks';
 export { type PingResponse } from './top-level';


### PR DESCRIPTION
## Summary

The `export { Webhooks } from './webhooks'` line was accidentally removed from `src/resources/index.ts` during a codegen/formatter update. This broke the `API.Webhooks` reference in `src/client.ts:1096` since `client.ts` imports `* as API from './resources/index'`.

Link to Devin session: https://app.devin.ai/sessions/d9b8d1f0909e45268eb7f87ae24f6426
Requested by: @hanlinc27